### PR TITLE
fix: include build directory in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "access": "public"
   },
   "files": [
-    "build"
+    "build",
+    "src"
   ],
   "author": "Artem Zakharchenko <kettanaito@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "build"
+  ],
   "author": "Artem Zakharchenko <kettanaito@gmail.com>",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
### What
This PR fixes an issue where the published package was missing the `build` directory, causing consumers to receive raw source files instead of the compiled output.

### Why
The `files` field in `package.json` was missing, resulting in the exclusion of the `build` directory from the published package.

### How
Added the `files` field to `package.json`, explicitly including the `build` directory.

### Testing
- Verified with `pnpm pack` that the resulting tarball includes the `build` directory.
- Confirmed that the package installs correctly and the `toSocketIo` export works as expected.
